### PR TITLE
[REFACTOR] BeforeAction이 항상 fail이여서 소리 출력 잘못되는 에러 해결

### DIFF
--- a/frontend/src/pages/Yoga/TreeCorrection.js
+++ b/frontend/src/pages/Yoga/TreeCorrection.js
@@ -27,6 +27,8 @@ const treeStandardAngle = {
   left_arm: 39.6,
 };
 
+let beforeActoion=true;
+
 export const treeRightLegAngle = (poses) => {
   const rightHip = poses[0].keypoints[12];
   const rightKnee = poses[0].keypoints[14];
@@ -53,7 +55,7 @@ export const treeRightLegAngle = (poses) => {
     rLegAngle = angle;
   }
 
-  let beforeActoion=false;
+
 
   const fail = new SpeechSynthesisUtterance("다리를 올리세요");
   fail.lang='ko-KR';

--- a/frontend/src/pages/Yoga/Yoga.js
+++ b/frontend/src/pages/Yoga/Yoga.js
@@ -182,11 +182,11 @@ const Yoga = () => {
                   let conName = connection.toUpperCase();
                   drawSegment(
                     ctx,
-                    [keypoint.x * 1.5, keypoint.y * 1.5], // 현재 keypoint의 좌표
+                    [keypoint.x, keypoint.y], // 현재 keypoint의 좌표
                     [
                       // 연결되어야 하는 connection의 좌표
-                      keypoints[POINTS[conName]].x * 1.5,
-                      keypoints[POINTS[conName]].y * 1.5,
+                      keypoints[POINTS[conName]].x,
+                      keypoints[POINTS[conName]].y,
                     ],
                     skeletonColor
                   );


### PR DESCRIPTION
### 이전 동작
beforeAction이 항상 fail로, fail(이전 fail 현재도 fail), success(이전 fail,현재 success)에 해당하는 컨솔 값만 출력되었다.

### 변경 사항
beforeAction을 export밖으로 선언해서,  beforeAction값이 변경되고 이 값이 저장되도록 하였다.